### PR TITLE
Update _xr_interop.py

### DIFF
--- a/odc/geo/_xr_interop.py
+++ b/odc/geo/_xr_interop.py
@@ -1024,17 +1024,12 @@ class ODCExtensionDa(ODCExtension):
         encoding = self._xx.encoding
 
         for k in ["nodata", "_FillValue"]:
-            nodata = attrs.get(k, ())
-            if nodata == ():
-                nodata = encoding.get(k, ())
-
-            if nodata == ():
-                continue
-
+            nodata = attrs.get(k, None)
             if nodata is None:
-                return None
+                nodata = encoding.get(k, None)
 
-            return float(nodata)
+            if nodata is not None:
+                return float(nodata)
 
         return None
 


### PR DESCRIPTION
Simplified the nodata property in ODCExtensionDa to make more readable, but also robust to "ValueError: The truth value of an empty array is ambiguous. Use `array.size > 0` to check that an array is not empty."